### PR TITLE
Refactor searcher

### DIFF
--- a/searcher.py
+++ b/searcher.py
@@ -11,6 +11,7 @@ import shutil  # High-level file operations
 import pandas
 import nltk
 
+
 class CustomFilter(Filter):
     # This filter will run for both the index and the query
     is_morph = True
@@ -31,97 +32,91 @@ class CustomFilter(Filter):
                 yield t
 
 
-def search(df, userQuery):
-    INDEX_DIR = "index/"
+class WhooshInterfacer:
 
-    # BUILD SCHEMA ****
-    # schema has fields - piece of info for each doc in the index
-    customWordFilter = RegexTokenizer() | LowercaseFilter() | CustomFilter(
-        nltk.stem.porter.PorterStemmer().stem) | CustomFilter(nltk.WordNetLemmatizer().lemmatize)
+    def __init__(self, path="index/"):
+        self.path=path
 
-    ixSchema = Schema(comment_ID=ID(stored=True),
+    def set_schema(self):
+        customWordFilter = RegexTokenizer() | \
+                           LowercaseFilter() | \
+                           CustomFilter(nltk.stem.porter.PorterStemmer().stem) | \
+                           CustomFilter(nltk.WordNetLemmatizer().lemmatize)
+
+        return Schema(comment_ID=ID(stored=True),
                       comment_Subreddit=ID(stored=True),
-                      # note analyzer is a wrapper for a tokenizer and zero or more filters -- i.e. allows you to combine them
-                      comment_Content=TEXT(analyzer=customWordFilter))
+                      comment_Content=TEXT(analyzer=customWordFilter),
+                      comment_Content_raw=STORED,
+                      )
 
-    # BUILD INDEX ****
+    def create_index(self):
+        schema = self.set_schema()
 
+        if not os.path.exists(self.path):
+            os.mkdir(self.path)
 
-    if not os.path.exists(INDEX_DIR):
-        os.mkdir(INDEX_DIR)
+        self.ix = Index.create_in(self.path, schema)
 
-    # if index exists - remove it
-    #     #Return True if path is an existing directory.
-    #     if os.path.isdir(INDEX_DIR):
-    #         #Delete an entire directory tree; path must point to a directory
-    #         shutil.rmtree(INDEX_DIR)
-    #     #create the directory for the index
-    #     os.makedirs(INDEX_DIR)
+    def fill_index(self, df):
+        with writing.BufferedWriter(self.ix, period=20, limit=1000) as writer :
+            for row in df.iterrows():
+                index, data = row
+                writer.add_document(comment_ID=data['name'],
+                                    comment_Subreddit=data['subreddit'],
+                                    comment_Content=data['body'],
+                                    comment_Content_raw=data['body'],
+                                    )
 
-    # initiate index - takes two inputs, the index directory and the schema for the index
-    ix = Index.create_in(INDEX_DIR, ixSchema)
+    def open_index(self):
+        self.ix = open_dir(self.path)
 
-    # INDEX COMMENTS ****
-    # creating a utility writer
-    # params: index – the whoosh.index.Index to write to.
-    # period – the maximum amount of time (in seconds) between commits.
-    # limit – the maximum number of documents to buffer before committing/between commits.
-    writer = writing.BufferedWriter(ix, period=20, limit=1000)
-    try:
-        # write each file to index
-        # enumerate returns index,value index points too --> index,a[index]
+    def search_keywords(self, terms):
+        userQuery = terms
+        qp = QueryParser("comment_Content", schema=self.ix.schema)
 
-        counter1 = 0
-        for row in df.iterrows():
-            index, data = row
-            writer.add_document(comment_ID=data['name'],
-                                comment_Subreddit=data['subreddit'],
-                                comment_Content=data['body'])
-            counter1 = counter1 + 1
+        # Once you have a QueryParser object, you can call parse() on it to parse a query string into a query object:
+        # default query lang:
+        # If the user doesn’t explicitly specify AND or OR clauses:
+        # by default, the parser treats the words as if they were connected by AND,
+        # meaning all the terms must be present for a document to match
+        # we will change this
+        # to phrase search "<query>" - use quotes
 
-            #             if (counter1 % 100 == 0):
-            #                 print("already indexed:", counter1+1)
-
-    finally:
-        # save the index
-        # print("done indexing")
-        # *** Note *** -> Must explictly call close() on the writer object to release the write lock and makesure uncommited changes are saved
-        writer.close()
+        qp.add_plugin(qparser.GtLtPlugin)
+        # qp.remove_plugin_class(qparser.PhrasePlugin)
+        qp.add_plugin(qparser.PhrasePlugin)
+        query = qp.parse(userQuery)
+        print("##Query: ")
+        print(query)
 
 
-        # PARSE USER QUERY ****
+        resultsDF = pandas.DataFrame()
+        with self.ix.searcher(weighting=scoring.BM25F()) as searcher:
+            queryResults = searcher.search(query, limit=None)
+            print("Total Number of Results:", len(queryResults))
+            print("Number of scored and sorted docs in this Results object:", queryResults.scored_length())
+            results = [item.fields() for item in queryResults]
 
-    # in the query parser --> we pass the DEFAULT field to search and the schema of the index we are searching
-    # NOTE: Users can still specify a search on a different field in the schema via --> <fieldname>: <query>
-    qp = QueryParser("comment_Content", schema=ix.schema)
+        resultsDF = pandas.DataFrame.from_dict(results)
+        resultsDF = resultsDF.rename(columns={'comment_ID': 'name', 
+                                              'comment_Subreddit': 'subreddit',
+                                              'comment_Content_raw': 'body',
+                                              })
+        return resultsDF
 
-    # Once you have a QueryParser object, you can call parse() on it to parse a query string into a query object:
-    # default query lang:
-    # If the user doesn’t explicitly specify AND or OR clauses:
-    # by default, the parser treats the words as if they were connected by AND,
-    # meaning all the terms must be present for a document to match
-    # we will change this
-    # to phrase search "<query>" - use quotes
 
-    qp.add_plugin(qparser.GtLtPlugin)
-    # qp.remove_plugin_class(qparser.PhrasePlugin)
-    qp.add_plugin(qparser.PhrasePlugin)
-    query = qp.parse(userQuery)
-    print("\n\n Query: ")
-    print(query)
-    print("\n\n")
+def search(df, userQuery):
+    """kept here for compatibility but this function will have to be removed."""
+    searcher = WhooshInterfacer("index_test")
+    searcher.create_index()
+    searcher.fill_index(df)
+    return searcher.search_keywords(userQuery)
 
-    ##IMPLEMENT SEARCHER ****
-    resultsDF = pandas.DataFrame()  # creates a new dataframe that's empty to store the results comment content
-    with ix.searcher(weighting=scoring.BM25F()) as searcher:
-        queryResults = searcher.search(query, limit=None)
-        print("Total Number of Results:", len(queryResults))
-        print("Number of scored and sorted docs in this Results object:", queryResults.scored_length())
-        for result in queryResults:
-            #             print(result)
-            #             print("\n",result['comment_ID'])
-            resultsDF = resultsDF.append(df.loc[df['name'] == result['comment_ID']][['name', 'subreddit', 'body']])
 
-    # print(dataDf.loc[dataDf['body']==comment].index.values[0])
-
-    return resultsDF
+if __name__ == "__main__":
+    import pandas
+    masterDF = pandas.read_pickle('commentDF.pkl')
+    searcher = WhooshInterfacer("index_test")
+    searcher.create_index()
+    searcher.fill_index(masterDF.head(1000))
+    resultsDF = searcher.search_keywords(terms='capital')

--- a/searcher.py
+++ b/searcher.py
@@ -70,8 +70,7 @@ class WhooshInterfacer:
     def open_index(self):
         self.ix = open_dir(self.path)
 
-    def search_keywords(self, terms):
-        userQuery = terms
+    def search_keywords(self, user_query, ranking_function=scoring.BM25F()):
         qp = QueryParser("comment_Content", schema=self.ix.schema)
 
         # Once you have a QueryParser object, you can call parse() on it to parse a query string into a query object:
@@ -89,13 +88,11 @@ class WhooshInterfacer:
         print("##Query: ")
         print(query)
 
-
-        resultsDF = pandas.DataFrame()
-        with self.ix.searcher(weighting=scoring.BM25F()) as searcher:
-            queryResults = searcher.search(query, limit=None)
-            print("Total Number of Results:", len(queryResults))
-            print("Number of scored and sorted docs in this Results object:", queryResults.scored_length())
-            results = [item.fields() for item in queryResults]
+        with self.ix.searcher(weighting=ranking_function) as searcher:
+            user_query = searcher.search(query, limit=None)
+            print("Total Number of Results:", len(user_query))
+            print("Number of scored and sorted docs in this Results object:", user_query.scored_length())
+            results = [item.fields() for item in user_query]
 
         resultsDF = pandas.DataFrame.from_dict(results)
         resultsDF = resultsDF.rename(columns={'comment_ID': 'name', 

--- a/searcher.py
+++ b/searcher.py
@@ -117,7 +117,7 @@ class Whoosher:
 
 def search(df, userQuery):
     """kept here for compatibility but this function will have to be removed."""
-    whoosher = Whoosher("index_test")
+    whoosher = Whoosher()
     whoosher.create_index()
     whoosher.fill_index(df)
     return whoosher.search_keywords(userQuery)

--- a/searcher.py
+++ b/searcher.py
@@ -32,7 +32,7 @@ class CustomFilter(Filter):
                 yield t
 
 
-class WhooshInterfacer:
+class Whoosher:
 
     def __init__(self, path="index/"):
         self.path=path
@@ -88,7 +88,7 @@ class WhooshInterfacer:
         qp.add_plugin(qparser.GtLtPlugin)
         # qp.remove_plugin_class(qparser.PhrasePlugin)
         qp.add_plugin(qparser.PhrasePlugin)
-        query = qp.parse(userQuery)
+        query = qp.parse(user_query)
         print("# user_query", user_query, ", Query: ", query)
         print(query)
 
@@ -108,17 +108,17 @@ class WhooshInterfacer:
 
 def search(df, userQuery):
     """kept here for compatibility but this function will have to be removed."""
-    searcher = WhooshInterfacer("index_test")
-    searcher.create_index()
-    searcher.fill_index(df)
-    return searcher.search_keywords(userQuery)
+    whoosher = Whoosher("index_test")
+    whoosher.create_index()
+    whoosher.fill_index(df)
+    return whoosher.search_keywords(userQuery)
 
 
 if __name__ == "__main__":
     import pandas
     masterDF = pandas.read_pickle('commentDF.pkl')
-    searcher = WhooshInterfacer("index_test")
-    searcher.create_index()
-    searcher.fill_index(masterDF.head(1000))
-    resultsDF = searcher.search_keywords(terms='capital')
+    whoosher = Whoosher("index_test")
+    whoosher.create_index()
+    whoosher.fill_index(masterDF.head(1000))
+    resultsDF = whoosher.search_keywords(user_query='capital')
     print('# resultsDF', resultsDF)

--- a/searcher.py
+++ b/searcher.py
@@ -117,3 +117,4 @@ if __name__ == "__main__":
     searcher.create_index()
     searcher.fill_index(masterDF.head(1000))
     resultsDF = searcher.search_keywords(terms='capital')
+    print('## resultsDF', resultsDF)


### PR DESCRIPTION
Changed the large monolithic `search` function into a class with several methods as suggested in https://github.com/ShopifyCapstone/SocialMediaAnalyzer/issues/1. It is mostly about moving code around. The `search` function is kept for compatibility reasons but it will need to be removed.

The code now pushes the full original content (non-stemmed `body`) into whoosh so search output can pull all the data from whoosh and not have to merge it back to df. Pushing the data to whoosh should now be made part of the preprocessing step.

You can also now run that file standalone by typing `python searcher.py` in the terminal to test it.
@jasonrizk @viebs @antonblo 